### PR TITLE
Compromise in favor of images

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = {
         ],
       },
       {
-        test: /\.(eot|svg|ttf|woff|woff2)$/,
+        test: /\.(eot|ttf|woff|woff2)$/,
         use: [
           {
             loader: 'url-loader',


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 

Remove support svg in fonts
Add support import svg in css

* **What is the current behavior?** 

When we import svg in css like 'background-image: url('kitty.svg')', we get error

* **What is the new behavior (_if this is a feature change_)?**

Now we can import svg images in css, like this 'background-image: url('kitty.svg')'

* **Does this PR introduce a breaking change?** 

Yes it does, now we cannot import font with svg extension

* **Other information**:
